### PR TITLE
fix: add missing abis in aavev3 pool handler (bis)

### DIFF
--- a/config/morpho-v1/subgraph.yaml
+++ b/config/morpho-v1/subgraph.yaml
@@ -568,6 +568,10 @@ templates:
           file: ../../abis/aave-v3/AaveV3Pool.json
         - name: MorphoAaveV3
           file: ../../abis/aave-v3/MorphoAaveV3.json
+        - name: AaveV3AddressesProvider
+          file: ../../abis/aave-v3/AaveV3AddressesProvider.json
+        - name: AaveV3PriceOracle
+          file: ../../abis/aave-v3/AaveV3PriceOracle.json
       eventHandlers:
         - event: BackUnbacked(indexed address,indexed address,uint256,uint256)
           handler: handleBackUnbacked


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change
- add templates missing to call `fetchAssetPriceAaveV3`
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->